### PR TITLE
Bump v1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vernier/godirect",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "browser": "dist/godirect.min.js",
   "main": "dist/godirect.min.umd.js",
   "module": "src/godirect.js",


### PR DESCRIPTION
Use UMD version for script tag, so type=“module” isn’t needed anymore