### PR TITLE
Polyfill TextDecoder if necessary, to provide Edge support

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "bundle": "rollup -c",
     "test": "npm run lint && jest"
   },
+  "dependencies": {
+    "text-encoding": "0.6.4"
+  },
   "license": "GPL-3.0",
   "description": "A JavaScript library to easily interact with [Vernier Go Direct® Sensors](https://www.vernier.com/products/sensors/go-direct-sensors).",
   "repository": {

--- a/src/Device.js
+++ b/src/Device.js
@@ -15,6 +15,16 @@ import {
 
 import { Sensor, MeasurementInfo, SensorSpecs } from './Sensor.js';
 
+// Use JS implemented TextDecoder if it is not provided by the browser.
+let _TextDecoder;
+const encoding = require('text-encoding');
+
+if (typeof TextDecoder === 'undefined') {
+  _TextDecoder = encoding.TextDecoder;
+} else {
+  _TextDecoder = TextDecoder;
+}
+
 export default class Device extends EventEmitter {
   constructor(device) {
     super();
@@ -419,7 +429,7 @@ export default class Device extends EventEmitter {
 
   _getDeviceInfo() {
     return this._sendCommand(commands.GET_INFO).then((response) => {
-      const decoder = new TextDecoder('utf-8');
+      const decoder = new _TextDecoder('utf-8');
 
       // OrderCode offset = 6 (header+cmd+counter)
       // Ordercode length = 16
@@ -448,7 +458,7 @@ export default class Device extends EventEmitter {
       // until I can get with Kevin to figure out what is going on.
       const sensorId = response.getUint32(2, true);
       if (sensorId > 0) {
-        const decoder = new TextDecoder('utf-8');
+        const decoder = new _TextDecoder('utf-8');
 
         const measurementInfo = new MeasurementInfo({
           type: response.getUint8(6), // 0 = Real64 or 1 = Int32


### PR DESCRIPTION
Support for MS Edge is a requirement for Scratch, but Edge does not provide TextDecoder:
https://caniuse.com/#search=TextDecoder

This PR checks if the global TextDecoder is unavailable, and if so replaces it with a node module. We use this module in several places in the same way in the Scratch codebase.