### PR TITLE
Fixes #67 write errors and #68 better open errors 

### DIFF
--- a/src/Device.js
+++ b/src/Device.js
@@ -363,7 +363,7 @@ export default class Device extends EventEmitter {
     command[2] = this._decRollingCounter();
     command[3] = this._calculateChecksum(command);
 
-    return this._queueWriteCommand(command, 0, command.length);
+    return this._queueWriteCommand(command);
   }
 
   // commands

--- a/src/Device.js
+++ b/src/Device.js
@@ -173,7 +173,7 @@ export default class Device extends EventEmitter {
             q.written = true;
           }
         }
-      }, 100);
+      }, 10);
     });
   }
 

--- a/src/Device.js
+++ b/src/Device.js
@@ -173,7 +173,7 @@ export default class Device extends EventEmitter {
             q.written = true;
           }
         }
-      }, 10);
+      }, 100);
     });
   }
 

--- a/src/WebBluetoothDeviceAdapter.js
+++ b/src/WebBluetoothDeviceAdapter.js
@@ -54,7 +54,7 @@ export default class WebBluetoothDeviceAdapter {
     }
 
     if (!(this.deviceCommand && this.deviceResponse)) {
-      throw new Error('Expected command and response characteristics not found.');
+      throw new Error('Expected command and response characteristics not found');
     }
   }
 

--- a/src/godirect.js
+++ b/src/godirect.js
@@ -24,7 +24,7 @@ const godirect = {
         await device.open(startMeasurements);
       } catch (err) {
         console.error(err);
-        throw err;
+        throw new Error(`Device Open Failed [${err}]`);
       }
     }
 


### PR DESCRIPTION
#67 was happening because if multiple write commands stacked up on each other the device was not happy about it. Really we need to ensure not only one write happens at a time but that the response has returned before blasting another command down to the device. By just adding the commands to the queue and having and interval write out of that queue we are able to control how we talk to the device. Most of the time the interval fires and does nothing but I am open to input on timeouts or different ways to accomplish what we need.

#68 Sometimes the device fails to get the command and response characteristics. In these cases the open failed but the caller wasn't aware of it. Removing the try/catch allowed the existing code to work as expected. 

Note: there was some additional cleanup in the library I did that shouldn't change functionality but makes the code cleaner and have better messages.