### PR TITLE
Fix write command timeouts and buffer size for WebUsbDeviceAdapter

### DIFF
--- a/src/WebUsbDeviceAdapter.js
+++ b/src/WebUsbDeviceAdapter.js
@@ -13,7 +13,9 @@ export default class WebUsbDeviceAdapter {
 
   async writeCommand(commandBuffer) {
     // Add the length of the command buffer as first byte
-    const tmp = new Uint8Array([commandBuffer.byteLength, ...commandBuffer]);
+    const tmp = new Uint8Array(64);
+    tmp[0] = commandBuffer.byteLength;
+    tmp.set(commandBuffer, 1);
     return this.webUsbNativeDevice.sendReport(this.reportId, tmp);
   }
 


### PR DESCRIPTION
We ran into a couple of bugs with the WebUsbDeviceAdapter:

* On some platforms, providing less than `maxPacketLength` bytes in `sendReport` would not send a full packet which would confuse the sensor.
* The writeQueue had problems with timeouts, such as if you attempt to send another command exactly 5 seconds after a previous command, the second command would be erroneously timed out.
